### PR TITLE
Rozwinięcie procesu decyzyjnego o szybsze kończenie głosowań

### DIFF
--- a/dokumenty/discord/proces-decyzyjny.md
+++ b/dokumenty/discord/proces-decyzyjny.md
@@ -64,9 +64,7 @@ sprawiedliwości.
     - Propozycja zostaje zaakceptowana, jeśli otrzyma większość głosów (ponad 50% członków rady).
     - Po zakończeniu głosowania Koordynator podsumowuje wyniki głosowania i przystępuje do realizacji zadania.
     - Głosowanie może zostać częściowo zamknięte, jeśli jedna z opcji („tak” lub „nie”) osiągnie wystarczająco mocną
-      przewagę i kolejne głosy nie zmienią już decyzji. W takim przypadku pozostałe osoby nadal mogą oddawać swoje
-      głosy do końca terminu, a Koordynator powinien sporządzić dwa podsumowania (pierwsze w momencie zatwierdzania
-      decyzji, drugie z finalnymi głosami po upływie terminu).
+      przewagę i kolejne głosy nie zmienią już decyzji.
 
 4. **Wdrożenie**:
     - Koordynator Zmian wdraża zaakceptowaną propozycję w terminie do 30 dni od jej zatwierdzenia, starając się jednak


### PR DESCRIPTION
Wprowadziłem niewielką propozycję zmiany, która ma na celu przyspieszenie procesu głosowania. Zakładam, że nie zawsze będziemy mieć dużą liczbę propozycji ani równą dostępność czasową przez cały rok. Dlatego proponuję wprowadzenie możliwości wcześniejszego zakończenia głosowania, gdy wynik jest już przesądzony, przy jednoczesnym pozostawieniu opcji głosowania dla pozostałych członków do końca ustalonego terminu. Po jego upływie pojawiłoby się dodatkowe, końcowe podsumowanie.

Sama możliwość wcześniejszego zamykania głosowań powinna pomóc nam sprawniej wdrażać zmiany.

Wszelkie komentarze i sugestie mile widziane :)