### PR TITLE
Stworzenie prostego pliku `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# --------------------------
+# IDE / Editors
+# --------------------------
+
+# JetBrains (IntelliJ, PhpStorm, PyCharm, WebStorm, etc.)
+.idea/
+
+# Visual Studio Code
+.vscode/
+*.code-workspace
+
+# --------------------------
+# Obsidian
+# --------------------------
+.obsidian/
+
+# --------------------------
+# System / OS files
+# --------------------------
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# --------------------------
+# Backup / temp files
+# --------------------------
+*.tmp
+*.temp
+*.bak
+*.swp
+*~


### PR DESCRIPTION
Wprowadzając poprzednie zmiany i modyfikacje na szybko, musiałem uważać na to aby nie dodać przez przypadek plików śmieciowych z obsidiana lub inteliji. Dodałem więc prosty plik `.gitignore`.

Jeśli ktoś używa innego edytora lub zauważa że coś pominąłem. Śmiało dajcie znać ;) 